### PR TITLE
fix: clone messages to ensure Solid store reactivity during streaming

### DIFF
--- a/src/use-chat.ts
+++ b/src/use-chat.ts
@@ -5,6 +5,7 @@ import {
   type UIMessage,
 } from 'ai';
 import { createEffect, createSignal, onCleanup, onMount } from 'solid-js';
+import { createStore, reconcile, unwrap } from 'solid-js/store';
 import { Chat } from './chat.solid';
 
 export type { CreateUIMessage, UIMessage };
@@ -96,6 +97,8 @@ export function useChat<UI_MESSAGE extends UIMessage = UIMessage>(
   options: UseChatOptions<UI_MESSAGE> = {},
 ): UseChatHelpers<UI_MESSAGE> {
   const { throttle: throttleWaitMs, resume = false, ...rest } = options;
+  const cloneMessages = (ms: UI_MESSAGE[]) =>
+    structuredClone(ms);
 
   // Create the chat instance
   const getInitialChat = (): Chat<UI_MESSAGE> => {
@@ -113,8 +116,8 @@ export function useChat<UI_MESSAGE extends UIMessage = UIMessage>(
   let lastChatRef = 'chat' in rest ? rest.chat : null;
 
   // Create signals for reactive state
-  const [messages, setMessagesSignal] = createSignal<UI_MESSAGE[]>(
-    chatInstance.messages,
+  const [messages, setMessagesStore] = createStore<UI_MESSAGE[]>(
+    cloneMessages(chatInstance.messages),
   );
   const [status, setStatus] = createSignal<AbstractChat<UI_MESSAGE>['status']>(
     chatInstance.status,
@@ -136,7 +139,12 @@ export function useChat<UI_MESSAGE extends UIMessage = UIMessage>(
       lastChatRef = currentChatRef;
 
       // Update signals with new chat state
-      setMessagesSignal(chatInstance.messages);
+      setMessagesStore(
+        reconcile(
+          cloneMessages(chatInstance.messages),
+          { key: "id" }
+        )
+      );
       setStatus(chatInstance.status);
       setError(chatInstance.error);
     }
@@ -150,7 +158,12 @@ export function useChat<UI_MESSAGE extends UIMessage = UIMessage>(
 
     // Subscribe to messages changes
     const unsubscribeMessages = chat['~registerMessagesCallback'](() => {
-      setMessagesSignal([...chat.messages]);
+      setMessagesStore(
+        reconcile(
+          cloneMessages(chat.messages),
+          { key: "id" }
+        )
+      );
     }, throttleWaitMs);
 
     // Subscribe to status changes
@@ -179,13 +192,19 @@ export function useChat<UI_MESSAGE extends UIMessage = UIMessage>(
 
   // setMessages function
   const setMessages = (
-    messagesParam: UI_MESSAGE[] | ((messages: UI_MESSAGE[]) => UI_MESSAGE[]),
+    messagesParam:
+      | UI_MESSAGE[]
+      | ((messages: UI_MESSAGE[]) => UI_MESSAGE[]),
   ) => {
     const chat = getChat();
-    if (typeof messagesParam === 'function') {
-      messagesParam = messagesParam(chat.messages);
-    }
-    chat.messages = messagesParam;
+    const next =
+      typeof messagesParam === "function"
+        ? messagesParam(chat.messages)
+        : messagesParam;
+    const plain = unwrap(next) as UI_MESSAGE[];
+
+    chat.messages = plain;
+    setMessagesStore(reconcile(cloneMessages(plain), { key: "id" }));
   };
 
   return {
@@ -195,7 +214,7 @@ export function useChat<UI_MESSAGE extends UIMessage = UIMessage>(
     get messages() {
       // Trigger reactivity check for chat recreation
       getChat();
-      return messages();
+      return messages;
     },
     setMessages,
     get sendMessage() {

--- a/src/use-chat.ui.test.tsx
+++ b/src/use-chat.ui.test.tsx
@@ -383,6 +383,160 @@ describe('data protocol stream', () => {
   });
 });
 
+describe('streaming text delta reactivity', () => {
+  let chatRef: Chat<UIMessage>;
+
+  setupTestComponent(() => {
+    const chat = new Chat({ generateId: mockId() });
+    chatRef = chat;
+    const helpers = useChat({ chat });
+
+    return (
+      <div>
+        <div data-testid="status">{helpers.status}</div>
+        <For each={helpers.messages}>
+          {m => (
+            <div data-testid={`msg-${m.role}`}>
+              <For each={m.parts}>
+                {p => <span>{p.type === 'text' ? p.text : ''}</span>}
+              </For>
+            </div>
+          )}
+        </For>
+        <button
+          data-testid="send"
+          onClick={() =>
+            helpers.sendMessage({ parts: [{ text: 'hi', type: 'text' }] })
+          }
+        />
+      </div>
+    );
+  });
+
+  it('should trigger reactivity for each text delta', async () => {
+    const controller = new TestResponseController();
+    server.urls['/api/chat'].response = {
+      type: 'controlled-stream',
+      controller,
+    };
+
+    await userEvent.click(screen.getByTestId('send'));
+
+    controller.write(formatChunk({ type: 'text-start', id: '0' }));
+    controller.write(
+      formatChunk({ type: 'text-delta', id: '0', delta: 'A' }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('msg-assistant')).toHaveTextContent('A');
+    });
+
+    controller.write(
+      formatChunk({ type: 'text-delta', id: '0', delta: 'B' }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('msg-assistant')).toHaveTextContent('AB');
+    });
+
+    controller.write(
+      formatChunk({ type: 'text-delta', id: '0', delta: 'C' }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('msg-assistant')).toHaveTextContent('ABC');
+    });
+
+    controller.write(formatChunk({ type: 'text-end', id: '0' }));
+    controller.close();
+  });
+});
+
+describe('message reference isolation', () => {
+  let chatRef: Chat<UIMessage>;
+  let getStoreMessages: () => UIMessage[];
+
+  setupTestComponent(() => {
+    const chat = new Chat({ generateId: mockId() });
+    chatRef = chat;
+    const helpers = useChat({ chat });
+    getStoreMessages = () => helpers.messages;
+
+    return (
+      <div>
+        <div data-testid="status">{helpers.status}</div>
+        <div data-testid="messages">{JSON.stringify(helpers.messages)}</div>
+        <For each={helpers.messages}>
+          {(m, idx) => (
+            <div data-testid={`msg-${idx()}`}>
+              {m.parts
+                .map(p => (p.type === 'text' ? p.text : ''))
+                .join('')}
+            </div>
+          )}
+        </For>
+        <button
+          data-testid="send"
+          onClick={() =>
+            helpers.sendMessage({ parts: [{ text: 'hi', type: 'text' }] })
+          }
+        />
+      </div>
+    );
+  });
+
+  it('should clone messages to prevent shared references', async () => {
+    server.urls['/api/chat'].response = {
+      type: 'stream-chunks',
+      chunks: [
+        formatChunk({ type: 'text-start', id: '0' }),
+        formatChunk({ type: 'text-delta', id: '0', delta: 'Hello' }),
+        formatChunk({ type: 'text-end', id: '0' }),
+      ],
+    };
+
+    await userEvent.click(screen.getByTestId('send'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('status')).toHaveTextContent('ready');
+    });
+
+    const storeMessages = getStoreMessages();
+    const instanceMessages = chatRef.messages;
+
+    // Arrays must be different references
+    expect(storeMessages).not.toBe(instanceMessages);
+    // Message objects must be different references
+    expect(storeMessages[0]).not.toBe(instanceMessages[0]);
+    expect(storeMessages[1]).not.toBe(instanceMessages[1]);
+    // Parts arrays must be different references
+    expect(storeMessages[1].parts).not.toBe(instanceMessages[1].parts);
+  });
+
+  it('should not reflect external mutations to chat instance', async () => {
+    server.urls['/api/chat'].response = {
+      type: 'stream-chunks',
+      chunks: [
+        formatChunk({ type: 'text-start', id: '0' }),
+        formatChunk({ type: 'text-delta', id: '0', delta: 'Original' }),
+        formatChunk({ type: 'text-end', id: '0' }),
+      ],
+    };
+
+    await userEvent.click(screen.getByTestId('send'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('msg-1')).toHaveTextContent('Original');
+    });
+
+    // Simulate SDK in-place mutation (the bug scenario)
+    (chatRef.messages[1].parts[0] as any).text = 'MUTATED';
+
+    // Store should still show original (cloned, isolated)
+    expect(screen.getByTestId('msg-1')).toHaveTextContent('Original');
+  });
+});
+
 describe('text stream', () => {
   let onFinishCalls: Array<{
     message: UIMessage;


### PR DESCRIPTION
Fix #2

## Summary
- Clone messages with structuredClone before reconcile to prevent SDK in-place mutations from bypassing Solid reactivity
- Add tests for streaming text delta reactivity and reference isolation
